### PR TITLE
Calling [super awakeFromNib];

### DIFF
--- a/SWSnapshotStackView.m
+++ b/SWSnapshotStackView.m
@@ -190,6 +190,7 @@
 
 - (void)awakeFromNib
 {
+  [super awakeFromNib];
   [self commonInitialisation];
 }
 


### PR DESCRIPTION
Building with Xcode 8 requires calling [super awakeFromNib].
